### PR TITLE
[bug-fix] define name from config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ const graphql = (document, config = {}) => {
   // gather operation info from the graphQL document
   const definitions = document.definitions[0];
   const operationType = document.definitions[0].operation;
+  const { name } = config;
   const clientOperationName = R.path(['name', 'value'], definitions);
   const schemaOperationName = R.path(
     ['selectionSet', 'selections', '0', 'name', 'value'],


### PR DESCRIPTION
"name" was never defined. The first option for "operationName" is the user-defined value of "name" from the provided config